### PR TITLE
Fix typos and edit text in doc comments

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -3,7 +3,7 @@ use core::mem::MaybeUninit;
 
 use either::{Either, Left, Right};
 
-/// A `Producer` emits a potentially infinite sequence, one item at a time.
+/// A `Producer` produces a potentially infinite sequence, one item at a time.
 ///
 /// The sequence consists of an arbitrary number of values of type `Self::Item`, followed by
 /// up to one value of type `Self::Final`. If you intend for the sequence to be infinite, use


### PR DESCRIPTION
The diff looks like a lot but it's mostly the introduction of newlines to make the docs more readable when viewing them in an editor.

Other changes are mostly minor typo corrections and grammatical changes.

There are still a few sentences which I find difficult to parse but we can iterate for clarity over time.